### PR TITLE
Add new adjustment form for data grid selection

### DIFF
--- a/ES-GUI/ES-GUI.csproj
+++ b/ES-GUI/ES-GUI.csproj
@@ -122,6 +122,12 @@
     <Compile Include="Form1.Designer.cs">
       <DependentUpon>Form1.cs</DependentUpon>
     </Compile>
+    <Compile Include="FrmAdjust.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="FrmAdjust.Designer.cs">
+      <DependentUpon>FrmAdjust.cs</DependentUpon>
+    </Compile>
     <Compile Include="Helpers.cs" />
     <Compile Include="MapController.cs" />
     <Compile Include="Injector.cs" />
@@ -145,6 +151,9 @@
     </EmbeddedResource>
     <EmbeddedResource Include="Form1.resx">
       <DependentUpon>Form1.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="FrmAdjust.resx">
+      <DependentUpon>FrmAdjust.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="Properties\Resources.resx">
       <Generator>ResXFileCodeGenerator</Generator>

--- a/ES-GUI/Form1.Designer.cs
+++ b/ES-GUI/Form1.Designer.cs
@@ -220,6 +220,7 @@
             this.label6 = new System.Windows.Forms.Label();
             this.quickShifterMode = new System.Windows.Forms.ComboBox();
             this.quickShifterEnabled = new System.Windows.Forms.CheckBox();
+            this.btnAdjustSelection = new System.Windows.Forms.Button();
             this.toolStrip1.SuspendLayout();
             this.tabControl1.SuspendLayout();
             this.tabPage1.SuspendLayout();
@@ -922,6 +923,7 @@
             // 
             // tabPage5
             // 
+            this.tabPage5.Controls.Add(this.btnAdjustSelection);
             this.tabPage5.Controls.Add(this.button6);
             this.tabPage5.Controls.Add(this.pictureBox2);
             this.tabPage5.Controls.Add(this.pictureBox1);
@@ -2404,6 +2406,16 @@
             this.quickShifterEnabled.UseVisualStyleBackColor = true;
             this.quickShifterEnabled.CheckedChanged += new System.EventHandler(this.quickShifterEnabled_CheckedChanged);
             // 
+            // btnAdjustSelection
+            // 
+            this.btnAdjustSelection.Location = new System.Drawing.Point(19, 434);
+            this.btnAdjustSelection.Name = "btnAdjustSelection";
+            this.btnAdjustSelection.Size = new System.Drawing.Size(102, 23);
+            this.btnAdjustSelection.TabIndex = 19;
+            this.btnAdjustSelection.Text = "Adjust Selection";
+            this.btnAdjustSelection.UseVisualStyleBackColor = true;
+            this.btnAdjustSelection.Click += new System.EventHandler(this.btnAdjustSelection_Click);
+            // 
             // Form1
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -2692,6 +2704,7 @@
         private System.Windows.Forms.RadioButton air2000Button;
         private System.Windows.Forms.CheckBox scfmSmoothing;
         private System.Windows.Forms.CheckBox tempSmoothing;
+        private System.Windows.Forms.Button btnAdjustSelection;
     }
 }
 

--- a/ES-GUI/Form1.cs
+++ b/ES-GUI/Form1.cs
@@ -1351,5 +1351,18 @@ namespace ES_GUI
             dynoChart.DrawToBitmap(bitmap, new Rectangle(0, 0, bitmap.Width, bitmap.Height));
             Clipboard.SetImage(bitmap);
         }
+
+        private void btnAdjustSelection_Click(object sender, EventArgs e)
+        {
+            //Get the current selected cells from the grid of the currently selected client.custommap
+            var sel = client.customMaps[tabControl2.SelectedIndex].GridView.SelectedCells;
+
+            var frmGridSelectionAdj = new FrmAdjust(ref sel);
+            var dialogResult = frmGridSelectionAdj.ShowDialog();
+            if ((uint)(dialogResult - 1) <= 1u)
+            {
+                frmGridSelectionAdj.Dispose();
+            }
+        }
     }
 }

--- a/ES-GUI/FrmAdjust.Designer.cs
+++ b/ES-GUI/FrmAdjust.Designer.cs
@@ -1,0 +1,171 @@
+﻿namespace ES_GUI
+{
+    partial class FrmAdjust
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.components = new System.ComponentModel.Container();
+            this.rbPercent = new System.Windows.Forms.RadioButton();
+            this.rbAdd = new System.Windows.Forms.RadioButton();
+            this.rbSet = new System.Windows.Forms.RadioButton();
+            this.tbPercent = new System.Windows.Forms.TextBox();
+            this.tbAdd = new System.Windows.Forms.TextBox();
+            this.tbSet = new System.Windows.Forms.TextBox();
+            this.btnCancel = new System.Windows.Forms.Button();
+            this.btnOK = new System.Windows.Forms.Button();
+            this.errorProvider1 = new System.Windows.Forms.ErrorProvider(this.components);
+            ((System.ComponentModel.ISupportInitialize)(this.errorProvider1)).BeginInit();
+            this.SuspendLayout();
+            // 
+            // rbPercent
+            // 
+            this.rbPercent.AutoSize = true;
+            this.rbPercent.Location = new System.Drawing.Point(12, 12);
+            this.rbPercent.Name = "rbPercent";
+            this.rbPercent.Size = new System.Drawing.Size(103, 17);
+            this.rbPercent.TabIndex = 0;
+            this.rbPercent.TabStop = true;
+            this.rbPercent.Text = "Percentage (+/-)";
+            this.rbPercent.UseVisualStyleBackColor = true;
+            this.rbPercent.Click += new System.EventHandler(this.rbPercent_Click);
+            // 
+            // rbAdd
+            // 
+            this.rbAdd.AutoSize = true;
+            this.rbAdd.Location = new System.Drawing.Point(12, 40);
+            this.rbAdd.Name = "rbAdd";
+            this.rbAdd.Size = new System.Drawing.Size(97, 17);
+            this.rbAdd.TabIndex = 1;
+            this.rbAdd.TabStop = true;
+            this.rbAdd.Text = "Add Value (+/-)";
+            this.rbAdd.UseVisualStyleBackColor = true;
+            this.rbAdd.Click += new System.EventHandler(this.rbAdd_Click);
+            // 
+            // rbSet
+            // 
+            this.rbSet.AutoSize = true;
+            this.rbSet.Location = new System.Drawing.Point(12, 70);
+            this.rbSet.Name = "rbSet";
+            this.rbSet.Size = new System.Drawing.Size(83, 17);
+            this.rbSet.TabIndex = 2;
+            this.rbSet.TabStop = true;
+            this.rbSet.Text = "Direct Value";
+            this.rbSet.UseVisualStyleBackColor = true;
+            this.rbSet.Click += new System.EventHandler(this.rbSet_Click);
+            // 
+            // tbPercent
+            // 
+            this.tbPercent.Location = new System.Drawing.Point(130, 11);
+            this.tbPercent.Name = "tbPercent";
+            this.tbPercent.Size = new System.Drawing.Size(74, 20);
+            this.tbPercent.TabIndex = 3;
+            this.tbPercent.Text = "0";
+            this.tbPercent.Enter += new System.EventHandler(this.tbPercent_Enter);
+            this.tbPercent.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.tbPercent_KeyPress);
+            this.tbPercent.Validating += new System.ComponentModel.CancelEventHandler(this.textBoxValidating);
+            // 
+            // tbAdd
+            // 
+            this.tbAdd.Location = new System.Drawing.Point(130, 39);
+            this.tbAdd.Name = "tbAdd";
+            this.tbAdd.Size = new System.Drawing.Size(74, 20);
+            this.tbAdd.TabIndex = 4;
+            this.tbAdd.Text = "0";
+            this.tbAdd.Enter += new System.EventHandler(this.tbAdd_Enter);
+            this.tbAdd.Validating += new System.ComponentModel.CancelEventHandler(this.textBoxValidating);
+            // 
+            // tbSet
+            // 
+            this.tbSet.Location = new System.Drawing.Point(130, 69);
+            this.tbSet.Name = "tbSet";
+            this.tbSet.Size = new System.Drawing.Size(74, 20);
+            this.tbSet.TabIndex = 5;
+            this.tbSet.Text = "0";
+            this.tbSet.Enter += new System.EventHandler(this.tbSet_Enter);
+            this.tbSet.Validating += new System.ComponentModel.CancelEventHandler(this.textBoxValidating);
+            // 
+            // btnCancel
+            // 
+            this.btnCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            this.btnCancel.Location = new System.Drawing.Point(12, 100);
+            this.btnCancel.Name = "btnCancel";
+            this.btnCancel.Size = new System.Drawing.Size(85, 23);
+            this.btnCancel.TabIndex = 6;
+            this.btnCancel.Text = "Cancel";
+            this.btnCancel.UseVisualStyleBackColor = true;
+            this.btnCancel.Click += new System.EventHandler(this.btnCancel_Click);
+            // 
+            // btnOK
+            // 
+            this.btnOK.Location = new System.Drawing.Point(130, 100);
+            this.btnOK.Name = "btnOK";
+            this.btnOK.Size = new System.Drawing.Size(74, 23);
+            this.btnOK.TabIndex = 7;
+            this.btnOK.Text = "OK";
+            this.btnOK.UseVisualStyleBackColor = true;
+            this.btnOK.Click += new System.EventHandler(this.btnOk_Click);
+            // 
+            // errorProvider1
+            // 
+            this.errorProvider1.ContainerControl = this;
+            // 
+            // FrmAdjust
+            // 
+            this.AcceptButton = this.btnOK;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.CancelButton = this.btnCancel;
+            this.ClientSize = new System.Drawing.Size(225, 130);
+            this.Controls.Add(this.btnOK);
+            this.Controls.Add(this.btnCancel);
+            this.Controls.Add(this.tbSet);
+            this.Controls.Add(this.tbAdd);
+            this.Controls.Add(this.tbPercent);
+            this.Controls.Add(this.rbSet);
+            this.Controls.Add(this.rbAdd);
+            this.Controls.Add(this.rbPercent);
+            this.Name = "FrmAdjust";
+            this.Text = "Adjust Selection";
+            ((System.ComponentModel.ISupportInitialize)(this.errorProvider1)).EndInit();
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.RadioButton rbPercent;
+        private System.Windows.Forms.RadioButton rbAdd;
+        private System.Windows.Forms.RadioButton rbSet;
+        private System.Windows.Forms.TextBox tbPercent;
+        private System.Windows.Forms.TextBox tbAdd;
+        private System.Windows.Forms.TextBox tbSet;
+        private System.Windows.Forms.Button btnCancel;
+        private System.Windows.Forms.Button btnOK;
+        private System.Windows.Forms.ErrorProvider errorProvider1;
+    }
+}

--- a/ES-GUI/FrmAdjust.cs
+++ b/ES-GUI/FrmAdjust.cs
@@ -1,0 +1,138 @@
+﻿using DocumentFormat.OpenXml.Office2010.CustomUI;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using static System.Windows.Forms.VisualStyles.VisualStyleElement.Rebar;
+
+namespace ES_GUI
+{
+    public partial class FrmAdjust : Form
+    {
+        private DataGridViewSelectedCellCollection dataGridViewSelectedCellCollection;
+
+        public FrmAdjust(ref DataGridViewSelectedCellCollection sel)
+        {
+            InitializeComponent();
+            dataGridViewSelectedCellCollection = sel;
+
+        }
+
+        private void rbAdd_Click(object sender, EventArgs e)
+        {
+            tbAdd.Focus();
+        }
+
+        private void rbPercent_Click(object sender, EventArgs e)
+        {
+            tbPercent.Focus();
+        }
+
+        private void rbSet_Click(object sender, EventArgs e)
+        {
+            tbSet.Focus();
+        }
+
+        private void tbPercent_Enter(object sender, EventArgs e)
+        {
+            rbPercent.Checked = true;
+        }
+
+        private void tbPercent_KeyPress(object sender, KeyPressEventArgs e)
+        {
+            if (e.KeyChar == '\u001b')
+            {
+                TextBox textBox = (TextBox)sender;
+                textBox.Text = "0";
+            }
+        }
+
+        private void textBoxValidating(object sender, CancelEventArgs e)
+        {
+            TextBox textBox = (TextBox)sender;
+            if (textBox.Text != string.Empty)
+            {
+                if (!CheckPercentage(textBox.Text.ToString()))
+                {
+                    errorProvider1.SetError(textBox, "Invalid input");
+                    e.Cancel = true;
+                }
+                else
+                {
+                    errorProvider1.SetError(textBox, "");
+                }
+            }
+        }
+
+        private void tbAdd_Enter(object sender, EventArgs e)
+        {
+            rbAdd.Checked = true;
+        }
+
+        private void tbSet_Enter(object sender, EventArgs e)
+        {
+            rbSet.Checked = true;
+        }
+
+        public bool CheckPercentage(string string_8)
+        {
+            double result;
+            return double.TryParse(Convert.ToString(string_8), NumberStyles.Any, NumberFormatInfo.CurrentInfo, out result);
+        }
+
+        private void btnOk_Click(object sender, EventArgs e)
+        {
+            if (rbPercent.Checked)
+            {
+                if (tbPercent.Text == string.Empty || tbPercent.Text == "0")
+                {
+                    return;
+                }
+                for (int i = 0; i < dataGridViewSelectedCellCollection.Count; i++)
+                {
+                    float value = float.Parse(dataGridViewSelectedCellCollection[i].Value.ToString());
+                    dataGridViewSelectedCellCollection[i].Value = (value + value / 100f * float.Parse(tbPercent.Text));
+                }
+            }
+            else if (rbAdd.Checked)
+            {
+                if (tbAdd.Text == string.Empty)
+                {
+                    return;
+                }
+                for (int j = 0; j < dataGridViewSelectedCellCollection.Count; j++)
+                {
+                    float value = float.Parse(dataGridViewSelectedCellCollection[j].Value.ToString());
+                    dataGridViewSelectedCellCollection[j].Value = value + float.Parse(tbAdd.Text);
+                }
+            }
+            else if (rbSet.Checked)
+            {
+                if (tbSet.Text == string.Empty)
+                {
+                    return;
+                }
+
+                for (int k = 0; k < dataGridViewSelectedCellCollection.Count; k++)
+                {
+                    dataGridViewSelectedCellCollection[k].Value = float.Parse(tbSet.Text);
+                }
+            }
+            this.Close();
+        }
+
+        private void btnCancel_Click(object sender, EventArgs e)
+        {
+            dataGridViewSelectedCellCollection = null;
+            tbAdd.Text = "0";
+            tbPercent.Text = "0";
+            tbSet.Text = "0";
+        }
+    }
+}

--- a/ES-GUI/FrmAdjust.resx
+++ b/ES-GUI/FrmAdjust.resx
@@ -1,0 +1,123 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <metadata name="errorProvider1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+</root>


### PR DESCRIPTION
Added FrmAdjust form which provides functionality to adjust the selection of data in data grid by percentages, addition or direct value. This form and associated buttons are created and integrated with the DataGridView and map controls. Moreover, the interpolation functionality for row and column data is also added via the Alt+V and Alt+H shortcut respectively